### PR TITLE
remove jsonl output suport from WikidataJsonDump

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 qwikidata Change Log
 ====================
 
+v0.2.0
+======
+
+**Removed**:
+
+* Jsonl output support from `WikidataJsonDump` class so that chunks produced by the class can always be read by the class.
+
 v0.1.5
 ======
 

--- a/qwikidata/__init__.py
+++ b/qwikidata/__init__.py
@@ -2,4 +2,4 @@
 """Metadata for this package."""
 
 __package_name__ = "qwikidata"
-__version__ = "0.1.5"
+__version__ = "0.2.0"


### PR DESCRIPTION
Removed `jsonl` output support from the WikidataJsonDump class so that chunks created by the class can always be read by the class. Bump to version 0.2.0
fyi @SultanOrazbayev 